### PR TITLE
feat: Защита от "давки в кеше"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Change Log
 ==========
 
+1.6.0
+-----
+
+### Добавлено:
+- Адаптер `\WebArch\BitrixCache\AntiStampedeCacheAdapter` с двойной защитой от
+    ["давки в кеше"](https://en.wikipedia.org/wiki/Cache_stampede) ("cache stampede"; другое название - "собачья
+    свалка", "dog piling") методами "блокировки"("locking") и "вероятностного преждевременного
+    устаревания"("probabilistic early expiration"), адаптированными из
+    [Symfony Cache 5.1](https://symfony.com/doc/5.1/components/cache.html)
+
+### Изменено:
+- Класс `\WebArch\BitrixCache\BitrixCache` игнорируется при составлении coverage отчёта
+
 1.5.1
 -----
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright 2017, Sergey Gripinskiy web-architect@mail.ru, Oleg Maksimenko <oleg.39style@gmail.com>
+Copyright 2017, Sergey Gripinskiy web-architect@mail.ru, Oleg Maksimenko <oleg.39style@gmail.com>,
+Nicolas Grekas <p@tchwork.com>
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
 following conditions are met:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "webarchitect609/bitrix-cache",
-  "description": "Comfortable fluent interface for Bitrix cache.",
+  "description": "Comfortable fluent interface for Bitrix cache. Anti-stampede cache protection.",
   "homepage": "https://github.com/webarchitect609/bitrix-cache",
   "keywords": [
     "bitrix",
@@ -19,11 +19,20 @@
       "name": "Oleg Maksimenko",
       "email": "oleg.39style@gmail.com",
       "role": "Contributor"
+    },
+    {
+      "name": "Nicolas Grekas",
+      "email": "p@tchwork.com",
+      "role": "Indirect Contributor"
     }
   ],
   "require": {
     "php": "^7.2",
-    "psr/simple-cache": "^1.0"
+    "psr/log": "^1.1",
+    "psr/simple-cache": "^1.0",
+    "symfony/cache-contracts": "^2.1",
+    "symfony/polyfill-php80": "^1.18",
+    "symfony/service-contracts": "^2.1"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",
@@ -52,7 +61,7 @@
     "check:analyse": "vendor/bin/phpstan analyse --ansi --no-progress",
     "check:code-style": "vendor/bin/php-cs-fixer fix --ansi --dry-run --diff",
     "check:security": "@composer update --no-suggest --no-interaction --dry-run roave/security-advisories",
-    "check:test": "vendor/bin/phpunit"
+    "check:test": "vendor/bin/phpunit --colors=always"
   },
   "scripts-descriptions": {
     "check:all": "Perform all the checks at once: code-style, static code analysis, unit tests and security.",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,9 @@
     <filter>
         <whitelist>
             <directory suffix=".php">src/main</directory>
+            <exclude>
+                <file>src/main/BitrixCache.php</file>
+            </exclude>
         </whitelist>
     </filter>
     <logging>

--- a/src/main/AntiStampedeCacheAdapter.php
+++ b/src/main/AntiStampedeCacheAdapter.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace WebArch\BitrixCache;
+
+use Bitrix\Main\Data\Cache as BitrixCache;
+use Closure;
+use Exception;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Service\ResetInterface;
+use WebArch\BitrixCache\Enum\CacheEngineType;
+use WebArch\BitrixCache\Enum\ErrorCode;
+use WebArch\BitrixCache\Exception\InvalidArgumentException;
+use WebArch\BitrixCache\Traits\AbstractAdapterTrait;
+use WebArch\BitrixCache\Traits\ContractsTrait;
+
+class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface, LoggerAwareInterface, ResetInterface
+{
+    use AbstractAdapterTrait;
+    use ContractsTrait;
+
+    /**
+     * @internal
+     */
+    protected const NS_SEPARATOR = ':';
+
+    /**
+     * This value indicates that the cache does not contain required key.
+     */
+    private const CACHE_MISS_VALUE = '0xDEADBEEF';
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var int
+     */
+    private $defaultLifetime;
+
+    /**
+     * @var string
+     */
+    private $baseDir;
+
+    /** @noinspection PhpUnusedParameterInspection */
+    public function __construct(
+        string $path = Cache::DEFAULT_PATH,
+        int $defaultLifetime = Cache::DEFAULT_TTL,
+        string $baseDir = Cache::DEFAULT_BASE_DIR
+    ) {
+        $this->setLogger(new NullLogger());
+        $this->maxIdLength = $this->getMaxIdLengthByEngineType(BitrixCache::getCacheEngineType());
+        $this->path = $path;
+        $this->defaultLifetime = $defaultLifetime;
+        $this->baseDir = $baseDir;
+        if (!is_numeric($this->maxIdLength) && strlen($this->baseDir . $this->path) > $this->maxIdLength - 24) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'BaseDir + Path must be %d chars max, %d given ("%s" + "%s")',
+                    $this->maxIdLength - 24,
+                    strlen($this->baseDir . $this->path),
+                    $this->baseDir,
+                    $this->path
+                ),
+                ErrorCode::BASE_DIR_AND_PATH_ARE_TOO_LONG
+            );
+        }
+        $this->createCacheItem = Closure::bind(
+            static function ($key, $value, $isHit) {
+                $v = $value;
+                $item = (new CacheItem())->setKey($key)
+                                         ->set($value)
+                                         ->setHit($isHit);
+                // Detect wrapped values that encode for their expiry and creation duration
+                // For compactness, these values are packed in the key of an array using
+                // magic numbers in the form 9D-..-..-..-..-00-..-..-..-5F
+                // @formatter:off
+                if (is_array($v) && 1 === count($v) && 10 === strlen($k = key($v)) && "\x9D" === $k[0] && "\0" === $k[5] && "\x5F" === $k[9]) {
+                    // @formatter:on
+                    $item->set($v[$k]);
+                    $v = unpack('Ve/Nc', substr($k, 1, -1));
+                    $metadata = $item->getMetadata();
+                    $metadata[CacheItem::METADATA_EXPIRY] = $v['e'] + CacheItem::METADATA_EXPIRY_OFFSET;
+                    $metadata[CacheItem::METADATA_CTIME] = $v['c'];
+                    $item->setMetadata($metadata);
+                }
+
+                return $item;
+            },
+            null,
+            CacheItem::class
+        );
+        $getId = Closure::fromCallable([$this, 'getId']);
+        $this->mergeByLifetime = Closure::bind(
+            static function ($deferred, $namespace, &$expiredIds) use ($getId, $defaultLifetime) {
+                $byLifetime = [];
+                $now = microtime(true);
+                $expiredIds = [];
+
+                foreach ($deferred as $key => $item) {
+                    $key = (string)$key;
+                    if (null === $item->expiry) {
+                        $ttl = 0 < $defaultLifetime ? $defaultLifetime : 0;
+                    } elseif (0 === $item->expiry) {
+                        $ttl = 0;
+                    } elseif (0 >= $ttl = (int)(0.1 + $item->expiry - $now)) {
+                        $expiredIds[] = $getId($key);
+                        continue;
+                    }
+                    if (isset(($metadata = $item->newMetadata)[CacheItem::METADATA_TAGS])) {
+                        unset($metadata[CacheItem::METADATA_TAGS]);
+                    }
+                    // `self` would be \Symfony\Contracts\Cache\ItemInterface, so there're no errors.
+                    // For compactness, expiry and creation duration are packed in the key of an array, using magic numbers as separators
+                    // @formatter:off
+                    /**
+                     * @noinspection PhpUndefinedClassConstantInspection
+                     * @phpstan-ignore-next-line
+                     */
+                    $byLifetime[$ttl][$getId($key)] = $metadata ? ["\x9D".pack('VN', (int) (0.1 + $metadata[self::METADATA_EXPIRY] - self::METADATA_EXPIRY_OFFSET), $metadata[self::METADATA_CTIME])."\x5F" => $item->value] : $item->value;
+                    // @formatter:on
+                }
+
+                return $byLifetime;
+            },
+            null,
+            CacheItem::class
+        );
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return bool
+     */
+    public function commit()
+    {
+        $ok = true;
+        $byLifetime = $this->mergeByLifetime;
+        $expiredIds = null;
+        $byLifetime = $byLifetime($this->deferred, $this->namespace, $expiredIds);
+        $retry = $this->deferred = [];
+        /** @phpstan-ignore-next-line */
+        if ($expiredIds) {
+            $this->doDelete($expiredIds);
+        }
+        foreach ($byLifetime as $lifetime => $values) {
+            try {
+                $e = $this->doSave($values, $lifetime);
+            } catch (Exception $e) {
+            }
+            /** @phpstan-ignore-next-line */
+            if (true === $e || [] === $e) {
+                continue;
+            }
+            /** @phpstan-ignore-next-line */
+            if (is_array($e) || 1 === count($values)) {
+                /** @phpstan-ignore-next-line */
+                foreach (is_array($e) ? $e : array_keys($values) as $id) {
+                    $ok = false;
+                    $v = $values[$id];
+                    $type = get_debug_type($v);
+                    $message = sprintf(
+                        'Failed to save key "{key}" of type %s%s',
+                        $type,
+                        $e instanceof Exception ? ': ' . $e->getMessage() : '.'
+                    );
+                    CacheItem::log(
+                        $this->logger,
+                        $message,
+                        [
+                            'key'           => substr($id, strlen($this->namespace)),
+                            'exception'     => $e instanceof Exception ? $e : null,
+                            'cache-adapter' => get_debug_type($this),
+                        ]
+                    );
+                }
+            } else {
+                foreach ($values as $id => $v) {
+                    $retry[$lifetime][] = $id;
+                }
+            }
+        }
+
+        // When bulk-save failed, retry each item individually
+        foreach ($retry as $lifetime => $ids) {
+            foreach ($ids as $id) {
+                try {
+                    $v = $byLifetime[$lifetime][$id];
+                    $e = $this->doSave([$id => $v], $lifetime);
+                } catch (Exception $e) {
+                }
+                /** @phpstan-ignore-next-line */
+                if (true === $e || [] === $e) {
+                    continue;
+                }
+                $ok = false;
+                $type = 'unknown';
+                if (isset($v)) {
+                    $type = get_debug_type($v);
+                }
+                $message = sprintf(
+                    'Failed to save key "{key}" of type %s%s',
+                    $type,
+                    $e instanceof Exception ? ': ' . $e->getMessage() : '.'
+                );
+                CacheItem::log(
+                    $this->logger,
+                    $message,
+                    [
+                        'key'           => substr($id, strlen($this->namespace)),
+                        'exception'     => $e instanceof Exception ? $e : null,
+                        'cache-adapter' => get_debug_type($this),
+                    ]
+                );
+            }
+        }
+
+        return $ok;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param array<string, mixed> $values
+     *
+     * @return bool
+     */
+    protected function doSave(array $values, int $lifetime)
+    {
+        return $this->getCache()->setMultiple($values, $lifetime);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return bool
+     */
+    protected function doHave(string $id)
+    {
+        return $this->getCache()->has($id);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param array<string> $ids
+     *
+     * @return array<string, mixed>
+     */
+    protected function doFetch(array $ids)
+    {
+        $result = [];
+        foreach ($this->getCache()->getMultiple($ids, self::CACHE_MISS_VALUE) as $key => $value) {
+            if (self::CACHE_MISS_VALUE === $value) {
+                continue;
+            }
+            $result[$key] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param array<string> $ids
+     *
+     * @return bool
+     */
+    protected function doDelete(array $ids)
+    {
+        return $this->getCache()->deleteMultiple($ids);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return bool
+     * @noinspection PhpUnusedParameterInspection
+     */
+    protected function doClear(string $namespace)
+    {
+        return $this->getCache()->clear();
+    }
+
+    /**
+     * @param string $engineType
+     *
+     * @return null|int
+     */
+    private function getMaxIdLengthByEngineType(string $engineType): ?int
+    {
+        if ($engineType === CacheEngineType::MEMCACHE) {
+            return 250;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Cache
+     */
+    protected function getCache(): Cache
+    {
+        return Cache::create()
+                    ->setBaseDir($this->baseDir)
+                    ->setPath($this->path)
+                    ->setTTL($this->defaultLifetime);
+    }
+}

--- a/src/main/Cache.php
+++ b/src/main/Cache.php
@@ -792,7 +792,7 @@ class Cache implements CacheInterface
     {
         if ($ttl <= 0) {
             throw new InvalidArgumentException(
-                'TTL must be positive number.',
+                'TTL must be positive number or zero.',
                 ErrorCode::NEGATIVE_OR_ZERO_TTL
             );
         }

--- a/src/main/CacheItem.php
+++ b/src/main/CacheItem.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace WebArch\BitrixCache;
+
+use DateInterval;
+use DateTime;
+use DateTimeInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use WebArch\BitrixCache\Enum\ErrorCode;
+use WebArch\BitrixCache\Exception\InvalidArgumentException;
+use WebArch\BitrixCache\Exception\LogicException;
+
+final class CacheItem implements ItemInterface
+{
+    /**
+     * @internal
+     */
+    public const METADATA_EXPIRY_OFFSET = 1527506807;
+
+    /**
+     * @var string
+     */
+    protected $key;
+
+    /**
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * @var bool
+     */
+    protected $isHit = false;
+
+    /**
+     * @var null|float
+     */
+    protected $expiry;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected $metadata = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected $newMetadata = [];
+
+    /**
+     * @var bool
+     */
+    protected $isTaggable = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isHit(): bool
+    {
+        return $this->isHit;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return $this
+     */
+    public function set($value): self
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return $this
+     */
+    public function expiresAt($expiration): self
+    {
+        if (null === $expiration) {
+            $this->expiry = null;
+        } elseif ($expiration instanceof DateTimeInterface) {
+            $this->expiry = (float)$expiration->format('U.u');
+        } else {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expiration date must implement DateTimeInterface or be null, "%s" given.',
+                    get_debug_type($expiration)
+                ),
+                ErrorCode::INVALID_EXPIRATION_DATE
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return $this
+     */
+    public function expiresAfter($time): self
+    {
+        if (null === $time) {
+            $this->expiry = null;
+        } elseif ($time instanceof DateInterval) {
+            $this->expiry = microtime(true)
+                + (float)DateTime::createFromFormat('U', '0')->add($time)->format('U.u');
+        } elseif (is_int($time)) {
+            $this->expiry = $time + microtime(true);
+        } else {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Expiration date must be an integer, a DateInterval or null, "%s" given.',
+                    get_debug_type($time)
+                ),
+                ErrorCode::INVALID_EXPIRATION
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tag($tags): ItemInterface
+    {
+        if (!$this->isTaggable) {
+            throw new LogicException(
+                sprintf('Cache item "%s" comes from a non tag-aware pool: you cannot tag it.', $this->key),
+                ErrorCode::NON_TAG_AWARE
+            );
+        }
+        if (!is_iterable($tags)) {
+            $tags = [$tags];
+        }
+        foreach ($tags as $tag) {
+            if (!is_string($tag)) {
+                throw new InvalidArgumentException(
+                    sprintf('Cache tag must be string, "%s" given.', get_debug_type($tag)),
+                    ErrorCode::INVALID_TAG
+                );
+            }
+            if (isset($this->newMetadata[self::METADATA_TAGS][$tag])) {
+                continue;
+            }
+            if ('' === $tag) {
+                throw new InvalidArgumentException(
+                    'Cache tag length must be greater than zero.',
+                    ErrorCode::EMPTY_TAG
+                );
+            }
+            if (false !== strpbrk($tag, self::RESERVED_CHARACTERS)) {
+                throw new InvalidArgumentException(
+                    sprintf('Cache tag "%s" contains reserved characters "%s".', $tag, self::RESERVED_CHARACTERS),
+                    ErrorCode::RESERVED_CHARACTERS_IN_TAG
+                );
+            }
+            $this->newMetadata[self::METADATA_TAGS][$tag] = $tag;
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return array<string, mixed>
+     */
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * Validates a cache key according to PSR-6.
+     *
+     * @param string $key The key to validate
+     *
+     * @throws InvalidArgumentException When $key is not valid
+     * @return string
+     */
+    public static function validateKey($key): string
+    {
+        if (!is_string($key)) {
+            throw new InvalidArgumentException(
+                sprintf('Cache key must be string, "%s" given.', get_debug_type($key)),
+                ErrorCode::INVALID_KEY_TYPE
+            );
+        }
+        if ('' === $key) {
+            throw new InvalidArgumentException(
+                'Cache key length must be greater than zero.',
+                ErrorCode::EMPTY_KEY
+            );
+        }
+        if (false !== strpbrk($key, self::RESERVED_CHARACTERS)) {
+            throw new InvalidArgumentException(
+                sprintf('Cache key "%s" contains reserved characters "%s".', $key, self::RESERVED_CHARACTERS),
+                ErrorCode::RESERVED_CHARACTERS_IN_KEY
+            );
+        }
+
+        return $key;
+    }
+
+    /**
+     * Internal logging helper.
+     *
+     * @param null|LoggerInterface $logger
+     * @param string $message
+     * @param array<mixed> $context
+     *
+     * @return void
+     * @internal
+     */
+    public static function log(?LoggerInterface $logger, string $message, array $context = []): void
+    {
+        if ($logger) {
+            $logger->warning($message, $context);
+        } else {
+            $replace = [];
+            foreach ($context as $k => $v) {
+                if (is_scalar($v)) {
+                    $replace['{' . $k . '}'] = $v;
+                }
+            }
+            @trigger_error(strtr($message, $replace), E_USER_WARNING);
+        }
+    }
+
+    /**
+     * @param mixed $key
+     *
+     * @return $this
+     * @internal
+     */
+    public function setKey($key)
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $isHit
+     *
+     * @return $this
+     * @internal
+     */
+    public function setHit(bool $isHit)
+    {
+        $this->isHit = $isHit;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     *
+     * @return $this
+     * @internal
+     */
+    public function setMetadata(array $metadata)
+    {
+        $this->metadata = $metadata;
+
+        return $this;
+    }
+}

--- a/src/main/Enum/CacheEngineType.php
+++ b/src/main/Enum/CacheEngineType.php
@@ -1,0 +1,17 @@
+<?php
+/** @noinspection PhpUnused */
+
+namespace WebArch\BitrixCache\Enum;
+
+class CacheEngineType
+{
+    const NONE = 'cacheenginenone';
+
+    const APC = 'cacheengineapc';
+
+    const XCACHE = 'cacheenginexcache';
+
+    const MEMCACHE = 'cacheenginememcache';
+
+    const FILES = 'cacheenginefiles';
+}

--- a/src/main/Enum/ErrorCode.php
+++ b/src/main/Enum/ErrorCode.php
@@ -39,4 +39,22 @@ class ErrorCode
     const EMPTY_TAG = 17;
 
     const INVALID_IBLOCK_ID = 18;
+
+    const INVALID_BETA = 19;
+
+    const INVALID_EXPIRATION = 20;
+
+    const INVALID_EXPIRATION_DATE = 21;
+
+    const NON_TAG_AWARE = 22;
+
+    const INVALID_TAG = 23;
+
+    const RESERVED_CHARACTERS_IN_TAG = 24;
+
+    const BASE_DIR_AND_PATH_ARE_TOO_LONG = 25;
+
+    const INVALID_KEY_TYPE = 26;
+
+    const RESERVED_CHARACTERS_IN_KEY = 27;
 }

--- a/src/main/Exception/BadMethodCallException.php
+++ b/src/main/Exception/BadMethodCallException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace WebArch\BitrixCache\Exception;
+
+use BadMethodCallException as CommonBadMethodCallException;
+use Psr\Cache\CacheException;
+use Psr\SimpleCache\CacheException as SimpleCacheException;
+
+class BadMethodCallException extends CommonBadMethodCallException implements CacheException, SimpleCacheException
+{
+}

--- a/src/main/Exception/InvalidArgumentException.php
+++ b/src/main/Exception/InvalidArgumentException.php
@@ -3,8 +3,9 @@
 namespace WebArch\BitrixCache\Exception;
 
 use InvalidArgumentException as CommonInvalidArgumentException;
+use Psr\Cache\InvalidArgumentException as PsrCacheInvalidArgumentException;
 use Psr\SimpleCache\InvalidArgumentException as SimpleCacheInvalidArgumentException;
 
-class InvalidArgumentException extends CommonInvalidArgumentException implements SimpleCacheInvalidArgumentException
+class InvalidArgumentException extends CommonInvalidArgumentException implements SimpleCacheInvalidArgumentException, PsrCacheInvalidArgumentException
 {
 }

--- a/src/main/Exception/LogicException.php
+++ b/src/main/Exception/LogicException.php
@@ -3,8 +3,9 @@
 namespace WebArch\BitrixCache\Exception;
 
 use LogicException as CommonLogicException;
-use Psr\SimpleCache\CacheException;
+use Psr\Cache\CacheException;
+use Psr\SimpleCache\CacheException as SimpleCacheException;
 
-class LogicException extends CommonLogicException implements CacheException
+class LogicException extends CommonLogicException implements CacheException, SimpleCacheException
 {
 }

--- a/src/main/Exception/RuntimeException.php
+++ b/src/main/Exception/RuntimeException.php
@@ -2,9 +2,10 @@
 
 namespace WebArch\BitrixCache\Exception;
 
-use Psr\SimpleCache\CacheException;
+use Psr\Cache\CacheException;
+use Psr\SimpleCache\CacheException as SimpleCacheException;
 use RuntimeException as CommonRuntimeException;
 
-class RuntimeException extends CommonRuntimeException implements CacheException
+class RuntimeException extends CommonRuntimeException implements CacheException, SimpleCacheException
 {
 }

--- a/src/main/LockRegistry.php
+++ b/src/main/LockRegistry.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace WebArch\BitrixCache;
+
+use Closure;
+use Exception;
+use Psr\Cache\InvalidArgumentException as PsrCacheInvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * LockRegistry is used internally by existing adapters to protect against cache stampede.
+ *
+ * It does so by wrapping the computation of items in a pool of locks.
+ * Foreach each apps, there can be at most 20 concurrent processes that
+ * compute items at the same time and only one per cache-key.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class LockRegistry
+{
+    /**
+     * @var array<int, resource>
+     */
+    private static $openedFiles = [];
+
+    /**
+     * @var array<int, bool>
+     */
+    private static $lockedFiles = [];
+
+    /**
+     * @var array<string> The number of items in this list controls the max number of concurrent processes.
+     */
+    private static $files = [
+        __DIR__ . DIRECTORY_SEPARATOR . 'AntiStampedeCacheAdapter.php',
+    ];
+
+    /**
+     * Defines a set of existing files that will be used as keys to acquire locks.
+     *
+     * @param array<string> $files
+     *
+     * @return array<string> The previously defined set of files
+     */
+    public static function setFiles(array $files): array
+    {
+        $previousFiles = self::$files;
+        self::$files = $files;
+
+        foreach (self::$openedFiles as $file) {
+            /** @phpstan-ignore-next-line */
+            if ($file) {
+                flock($file, LOCK_UN);
+                fclose($file);
+            }
+        }
+        self::$openedFiles = self::$lockedFiles = [];
+
+        return $previousFiles;
+    }
+
+    /**
+     * @param callable $callback
+     * @param ItemInterface $item
+     * @param bool $save
+     * @param AntiStampedeCacheAdapter $pool
+     * @param null|Closure $setMetadata
+     * @param null|LoggerInterface $logger
+     *
+     * @phpstan-ignore-next-line
+     * @throws PsrCacheInvalidArgumentException
+     * @throws Exception
+     * @return null|mixed
+     */
+    public static function compute(
+        callable $callback,
+        ItemInterface $item,
+        bool &$save,
+        AntiStampedeCacheAdapter $pool,
+        Closure $setMetadata = null,
+        LoggerInterface $logger = null
+    ) {
+        $key = self::$files ? crc32($item->getKey()) % count(self::$files) : -1;
+
+        /** @phpstan-ignore-next-line */
+        if ($key < 0 || (self::$lockedFiles[$key] ?? false) || !$lock = self::open($key)) {
+            return $callback($item, $save);
+        }
+
+        while (true) {
+            try {
+                // race to get the lock in non-blocking mode
+                $locked = flock($lock, LOCK_EX | LOCK_NB, $wouldBlock);
+
+                if ($locked || !$wouldBlock) {
+                    if ($logger) {
+                        $logger->info(
+                            sprintf('Lock %s, now computing item "{key}"', $locked ? 'acquired' : 'not supported'),
+                            ['key' => $item->getKey()]
+                        );
+                    }
+                    self::$lockedFiles[$key] = true;
+
+                    $value = $callback($item, $save);
+
+                    if ($save) {
+                        if ($setMetadata) {
+                            $setMetadata($item);
+                        }
+
+                        $pool->save($item->set($value));
+                        $save = false;
+                    }
+
+                    return $value;
+                }
+                // if we failed the race, retry locking in blocking mode to wait for the winner
+                if ($logger) {
+                    $logger->info(
+                        'Item "{key}" is locked, waiting for it to be released',
+                        ['key' => $item->getKey()]
+                    );
+                }
+                flock($lock, LOCK_SH);
+            } finally {
+                flock($lock, LOCK_UN);
+                unset(self::$lockedFiles[$key]);
+            }
+            static $signalingException, $signalingCallback;
+            if (is_null($signalingException)) {
+                $signalingException = unserialize("O:9:\"Exception\":1:{s:16:\"\0Exception\0trace\";a:0:{}}");
+            }
+            if (is_null($signalingCallback)) {
+                $signalingCallback = function () use ($signalingException) {
+                    throw $signalingException;
+                };
+            }
+
+            try {
+                $value = $pool->get($item->getKey(), $signalingCallback, 0);
+                if ($logger) {
+                    $logger->info(
+                        'Item "{key}" retrieved after lock was released',
+                        ['key' => $item->getKey()]
+                    );
+                }
+                $save = false;
+
+                return $value;
+            } catch (Exception $e) {
+                if ($signalingException !== $e) {
+                    throw $e;
+                }
+                if ($logger) {
+                    $logger->info(
+                        'Item "{key}" not found while lock was released, now retrying',
+                        ['key' => $item->getKey()]
+                    );
+                }
+            }
+        }
+
+        /** @phpstan-ignore-next-line */
+        return null;
+    }
+
+    /**
+     * @param int $key
+     *
+     * @return resource
+     */
+    private static function open(int $key)
+    {
+        $h = self::$openedFiles[$key] ?? null;
+        if (null !== $h) {
+            return $h;
+        }
+        set_error_handler(
+            function () {
+            }
+        );
+        try {
+            $h = fopen(self::$files[$key], 'r+');
+        } finally {
+            restore_error_handler();
+        }
+        self::$openedFiles[$key] = $h ?: @fopen(self::$files[$key], 'r');
+
+        return self::$openedFiles[$key];
+    }
+}

--- a/src/main/Traits/AbstractAdapterTrait.php
+++ b/src/main/Traits/AbstractAdapterTrait.php
@@ -1,0 +1,448 @@
+<?php
+
+namespace WebArch\BitrixCache\Traits;
+
+use Closure;
+use Exception;
+use Psr\Cache\CacheItemInterface;
+use Psr\Log\LoggerAwareTrait;
+use Traversable;
+use WebArch\BitrixCache\CacheItem;
+use WebArch\BitrixCache\Exception\BadMethodCallException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+trait AbstractAdapterTrait
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var Closure needs to be set by class, signature is function(string <key>, mixed <value>, bool <isHit>)
+     */
+    private $createCacheItem;
+
+    /**
+     * @var Closure needs to be set by class, signature is function(array <deferred>, string <namespace>, array
+     *     <&expiredIds>)
+     */
+    private $mergeByLifetime;
+
+    /**
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * @var string
+     */
+    private $namespaceVersion = '';
+
+    /**
+     * @var bool
+     */
+    private $versioningIsEnabled = false;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private $deferred = [];
+
+    /**
+     * @var array<string, string>
+     */
+    private $ids = [];
+
+    /**
+     * @var null|int The maximum length to enforce for identifiers or null when no limit applies
+     */
+    protected $maxIdLength;
+
+    /**
+     * Fetches several cache items.
+     *
+     * @param array $ids The cache identifiers to fetch
+     *
+     * @return array|Traversable The corresponding values found in the cache
+     */
+    abstract protected function doFetch(array $ids);
+
+    /**
+     * Confirms if the cache contains specified cache item.
+     *
+     * @param string $id The identifier for which to check existence
+     *
+     * @return bool True if item exists in the cache, false otherwise
+     */
+    abstract protected function doHave(string $id);
+
+    /**
+     * Deletes all items in the pool.
+     *
+     * @param string $namespace The prefix used for all identifiers managed by this pool
+     *
+     * @return bool True if the pool was successfully cleared, false otherwise
+     */
+    abstract protected function doClear(string $namespace);
+
+    /**
+     * Removes multiple items from the pool.
+     *
+     * @param array $ids An array of identifiers that should be removed from the pool
+     *
+     * @return bool True if the items were successfully removed, false otherwise
+     */
+    abstract protected function doDelete(array $ids);
+
+    /**
+     * Persists several cache items immediately.
+     *
+     * @param array $values The values to cache, indexed by their cache identifier
+     * @param int $lifetime The lifetime of the cached values, 0 for persisting until manual cleaning
+     *
+     * @return array|bool The identifiers that failed to be cached or a boolean stating if caching succeeded or not
+     */
+    abstract protected function doSave(array $values, int $lifetime);
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    public function hasItem($key)
+    {
+        $id = $this->getId($key);
+
+        if (isset($this->deferred[$key])) {
+            $this->commit();
+        }
+
+        try {
+            return $this->doHave($id);
+        } catch (Exception $e) {
+            CacheItem::log(
+                $this->logger,
+                'Failed to check if key "{key}" is cached: ' . $e->getMessage(),
+                ['key' => $key, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]
+            );
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    public function clear(string $prefix = '')
+    {
+        $this->deferred = [];
+        if ($cleared = $this->versioningIsEnabled) {
+            if ('' === $namespaceVersionToClear = $this->namespaceVersion) {
+                foreach ($this->doFetch([static::NS_SEPARATOR . $this->namespace]) as $v) {
+                    $namespaceVersionToClear = $v;
+                }
+            }
+            $namespaceToClear = $this->namespace . $namespaceVersionToClear;
+            $namespaceVersion = substr_replace(base64_encode(pack('V', mt_rand())), static::NS_SEPARATOR, 5);
+            try {
+                $cleared = $this->doSave([static::NS_SEPARATOR . $this->namespace => $namespaceVersion], 0);
+            } catch (Exception $e) {
+                $cleared = false;
+            }
+            /** @phpstan-ignore-next-line */
+            if ($cleared = true === $cleared || [] === $cleared) {
+                $this->namespaceVersion = $namespaceVersion;
+                $this->ids = [];
+            }
+        } else {
+            $namespaceToClear = $this->namespace . $prefix;
+        }
+
+        try {
+            return $this->doClear($namespaceToClear) || $cleared;
+        } catch (Exception $e) {
+            CacheItem::log(
+                $this->logger,
+                'Failed to clear the cache: ' . $e->getMessage(),
+                ['exception' => $e, 'cache-adapter' => get_debug_type($this)]
+            );
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    public function deleteItem($key)
+    {
+        return $this->deleteItems([$key]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    public function deleteItems(array $keys)
+    {
+        $ids = [];
+
+        foreach ($keys as $key) {
+            $ids[$key] = $this->getId($key);
+            unset($this->deferred[$key]);
+        }
+
+        try {
+            if ($this->doDelete($ids)) {
+                return true;
+            }
+        } catch (Exception $e) {
+        }
+
+        $ok = true;
+
+        // When bulk-delete failed, retry each item individually
+        foreach ($ids as $key => $id) {
+            try {
+                $e = null;
+                if ($this->doDelete([$id])) {
+                    continue;
+                }
+            } catch (Exception $e) {
+            }
+            $message = 'Failed to delete key "{key}"' . ($e instanceof Exception ? ': ' . $e->getMessage() : '.');
+            CacheItem::log(
+                $this->logger,
+                $message,
+                ['key' => $key, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]
+            );
+            $ok = false;
+        }
+
+        return $ok;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        if ($this->deferred) {
+            $this->commit();
+        }
+        $id = $this->getId($key);
+
+        $f = $this->createCacheItem;
+        $isHit = false;
+        $value = null;
+
+        try {
+            foreach ($this->doFetch([$id]) as $value) {
+                $isHit = true;
+            }
+
+            return $f($key, $value, $isHit);
+        } catch (Exception $e) {
+            CacheItem::log(
+                $this->logger,
+                'Failed to fetch key "{key}": ' . $e->getMessage(),
+                ['key' => $key, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]
+            );
+        }
+
+        return $f($key, null, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return iterable<string, mixed>
+     */
+    public function getItems(array $keys = [])
+    {
+        if ($this->deferred) {
+            $this->commit();
+        }
+        $ids = [];
+
+        foreach ($keys as $key) {
+            $ids[] = $this->getId($key);
+        }
+        try {
+            $items = $this->doFetch($ids);
+        } catch (Exception $e) {
+            CacheItem::log(
+                $this->logger,
+                'Failed to fetch items: ' . $e->getMessage(),
+                ['keys' => $keys, 'exception' => $e, 'cache-adapter' => get_debug_type($this)]
+            );
+            $items = [];
+        }
+        $ids = array_combine($ids, $keys);
+
+        return $this->generateItems($items, $ids);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    public function save(CacheItemInterface $item)
+    {
+        if (!$item instanceof CacheItem) {
+            return false;
+        }
+        $this->deferred[$item->getKey()] = $item;
+
+        return $this->commit();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return bool
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        if (!$item instanceof CacheItem) {
+            return false;
+        }
+        $this->deferred[$item->getKey()] = $item;
+
+        return true;
+    }
+
+    /**
+     * Enables/disables versioning of items.
+     *
+     * When versioning is enabled, clearing the cache is atomic and doesn't require listing existing keys to proceed,
+     * but old keys may need garbage collection and extra round-trips to the back-end are required.
+     *
+     * Calling this method also clears the memoized namespace version and thus forces a resynchonization of it.
+     *
+     * @param bool $enable
+     *
+     * @return bool the previous state of versioning
+     */
+    public function enableVersioning($enable = true)
+    {
+        $wasEnabled = $this->versioningIsEnabled;
+        $this->versioningIsEnabled = (bool)$enable;
+        $this->namespaceVersion = '';
+        $this->ids = [];
+
+        return $wasEnabled;
+    }
+
+    /**
+     * @return void
+     */
+    public function reset(): void
+    {
+        if ($this->deferred) {
+            $this->commit();
+        }
+        $this->namespaceVersion = '';
+        $this->ids = [];
+    }
+
+    public function __sleep()
+    {
+        throw new BadMethodCallException('Cannot serialize ' . __CLASS__);
+    }
+
+    public function __wakeup()
+    {
+        throw new BadMethodCallException('Cannot unserialize ' . __CLASS__);
+    }
+
+    public function __destruct()
+    {
+        if ($this->deferred) {
+            $this->commit();
+        }
+    }
+
+    /**
+     * @param iterable<string, mixed> $items
+     * @param array<string> $keys
+     *
+     * @return iterable<string, mixed>
+     */
+    private function generateItems(iterable $items, array &$keys): iterable
+    {
+        $f = $this->createCacheItem;
+
+        try {
+            foreach ($items as $id => $value) {
+                if (!isset($keys[$id])) {
+                    $id = key($keys);
+                }
+                $key = $keys[$id];
+                unset($keys[$id]);
+                yield $key => $f($key, $value, true);
+            }
+        } catch (Exception $e) {
+            CacheItem::log(
+                $this->logger,
+                'Failed to fetch items: ' . $e->getMessage(),
+                ['keys' => array_values($keys), 'exception' => $e, 'cache-adapter' => get_debug_type($this)]
+            );
+        }
+
+        foreach ($keys as $key) {
+            yield $key => $f($key, null, false);
+        }
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return string
+     */
+    private function getId(string $key): string
+    {
+        if ($this->versioningIsEnabled && '' === $this->namespaceVersion) {
+            $this->ids = [];
+            $this->namespaceVersion = '1' . static::NS_SEPARATOR;
+            try {
+                foreach ($this->doFetch([static::NS_SEPARATOR . $this->namespace]) as $v) {
+                    $this->namespaceVersion = $v;
+                }
+                if ('1' . static::NS_SEPARATOR === $this->namespaceVersion) {
+                    $this->namespaceVersion = substr_replace(base64_encode(pack('V', time())), static::NS_SEPARATOR, 5);
+                    $this->doSave([static::NS_SEPARATOR . $this->namespace => $this->namespaceVersion], 0);
+                }
+            } catch (Exception $e) {
+            }
+        }
+
+        if (is_string($key) && isset($this->ids[$key])) {
+            return $this->namespace . $this->namespaceVersion . $this->ids[$key];
+        }
+        CacheItem::validateKey($key);
+        $this->ids[$key] = $key;
+
+        if (null === $this->maxIdLength) {
+            return $this->namespace . $this->namespaceVersion . $key;
+        }
+        if (strlen($id = $this->namespace . $this->namespaceVersion . $key) > $this->maxIdLength) {
+            // Use MD5 to favor speed over security, which is not an issue here
+            $this->ids[$key] = $id = substr_replace(
+                base64_encode(hash('md5', $key, true)),
+                static::NS_SEPARATOR,
+                -(strlen($this->namespaceVersion) + 2)
+            );
+            $id = $this->namespace . $this->namespaceVersion . $id;
+        }
+
+        return $id;
+    }
+}

--- a/src/main/Traits/ContractsTrait.php
+++ b/src/main/Traits/ContractsTrait.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace WebArch\BitrixCache\Traits;
+
+use Closure;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\CacheTrait;
+use Symfony\Contracts\Cache\ItemInterface;
+use WebArch\BitrixCache\AntiStampedeCacheAdapter;
+use WebArch\BitrixCache\CacheItem;
+use WebArch\BitrixCache\Enum\ErrorCode;
+use WebArch\BitrixCache\Exception\InvalidArgumentException;
+use WebArch\BitrixCache\LockRegistry;
+
+trait ContractsTrait
+{
+    use CacheTrait {
+        doGet as private contractsGet;
+    }
+
+    /**
+     * @var callable
+     */
+    private $callbackWrapper = [LockRegistry::class, 'compute'];
+
+    /**
+     * @var array<string, string>
+     */
+    private $computing = [];
+
+    /**
+     * Wraps the callback passed to ->get() in a callable.
+     *
+     * @param null|callable $callbackWrapper
+     *
+     * @return callable the previous callback wrapper
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function setCallbackWrapper(?callable $callbackWrapper): callable
+    {
+        $previousWrapper = $this->callbackWrapper;
+        if (is_null($callbackWrapper)) {
+            $this->callbackWrapper = function (
+                callable $callback,
+                ItemInterface $item,
+                bool &$save,
+                CacheInterface $pool,
+                Closure $setMetadata,
+                ?LoggerInterface $logger
+            ) {
+                return $callback($item, $save);
+            };
+        } else {
+            $this->callbackWrapper = $callbackWrapper;
+        }
+
+        return $previousWrapper;
+    }
+
+    /**
+     * @param AntiStampedeCacheAdapter $pool
+     * @param string $key
+     * @param callable $callback
+     * @param null|float $beta
+     * @param null|array<string, mixed> $metadata
+     *
+     * @return mixed
+     */
+    protected function doGet(
+        AntiStampedeCacheAdapter $pool,
+        string $key,
+        callable $callback,
+        ?float $beta,
+        array &$metadata = null
+    ) {
+        if (0 > $beta = $beta ?? 1.0) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Argument "$beta" provided to "%s::get()" must be a positive number, %f given.',
+                    static::class,
+                    $beta
+                ),
+                ErrorCode::INVALID_BETA
+            );
+        }
+
+        static $setMetadata;
+
+        if (is_null($setMetadata)) {
+            $setMetadata = Closure::bind(
+                static function (CacheItem $item, float $startTime, ?array &$metadata) {
+                    if ($item->expiry > $endTime = microtime(true)) {
+                        $item->newMetadata[CacheItem::METADATA_EXPIRY] = $metadata[CacheItem::METADATA_EXPIRY] = $item->expiry;
+                        $item->newMetadata[CacheItem::METADATA_CTIME] = $metadata[CacheItem::METADATA_CTIME] =
+                            (int)ceil(1000 * ($endTime - $startTime));
+                    } else {
+                        unset($metadata[CacheItem::METADATA_EXPIRY], $metadata[CacheItem::METADATA_CTIME]);
+                    }
+                },
+                null,
+                CacheItem::class
+            );
+        }
+
+        return $this->contractsGet(
+            $pool,
+            $key,
+            function (CacheItem $item, bool &$save) use ($pool, $callback, $setMetadata, &$metadata, $key) {
+                // don't wrap nor save recursive calls
+                if (isset($this->computing[$key])) {
+                    $value = $callback($item, $save);
+                    $save = false;
+
+                    return $value;
+                }
+
+                $this->computing[$key] = $key;
+                $startTime = microtime(true);
+
+                try {
+                    $value = ($this->callbackWrapper)(
+                        $callback,
+                        $item,
+                        $save,
+                        $pool,
+                        function (CacheItem $item) use ($setMetadata, $startTime, &$metadata) {
+                            $setMetadata($item, $startTime, $metadata);
+                        },
+                        $this->logger ?? null
+                    );
+                    $setMetadata($item, $startTime, $metadata);
+
+                    return $value;
+                } finally {
+                    unset($this->computing[$key]);
+                }
+            },
+            $beta,
+            $metadata,
+            $this->logger ?? null
+        );
+    }
+}

--- a/src/test/AntiStampedeCacheAdapterTest.php
+++ b/src/test/AntiStampedeCacheAdapterTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace WebArch\BitrixCache\Test;
+
+use LogicException;
+use Psr\Cache\InvalidArgumentException;
+use WebArch\BitrixCache\CacheItem;
+use WebArch\BitrixCache\Test\Fixture\AntiStampedeCacheAdapterFixture;
+
+class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
+{
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->mockCache();
+        $this->setUpAntiStampedeCacheAdapter();
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     * @throws InvalidArgumentException
+     * @return void
+     */
+    public function testGetMisses(): void
+    {
+        $this->cache->expects($this->once())
+                    ->method('getMultiple')
+                    ->willReturn([$this->key => $this->cacheMissValue]);
+
+        $this->cache->expects($this->once())
+                    ->method('setMultiple');
+
+        $this->cache->expects($this->never())
+                    ->method('clear');
+
+        $this->cache->expects($this->never())
+                    ->method('deleteMultiple');
+
+        $this->cache->expects($this->never())
+                    ->method('has');
+
+        $value = $this->cacheAdapter->get(
+            $this->key,
+            function (CacheItem $cacheItem) {
+                $cacheItem->expiresAfter(60);
+
+                return $this->cachedValue;
+            }
+        );
+
+        $this->assertEquals($this->cachedValue, $value);
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     * @throws InvalidArgumentException
+     * @return void
+     */
+    public function testGetHits(): void
+    {
+        $this->cache->expects($this->once())
+                    ->method('getMultiple')
+                    ->willReturn([$this->key => $this->cachedValue]);
+
+        $this->cache->expects($this->never())
+                    ->method('setMultiple');
+
+        $this->cache->expects($this->never())
+                    ->method('clear');
+
+        $this->cache->expects($this->never())
+                    ->method('deleteMultiple');
+
+        $this->cache->expects($this->never())
+                    ->method('has');
+
+        $value = $this->cacheAdapter->get(
+            $this->key,
+            function () {
+                throw new LogicException('This closure should not be called, if the cache hits!');
+            }
+        );
+
+        $this->assertEquals($this->cachedValue, $value);
+    }
+
+    /**
+     * @phpstan-ignore-next-line
+     * @throws InvalidArgumentException
+     * @return void
+     */
+    public function testGetThrowsException(): void
+    {
+        $this->cache->expects($this->once())
+                    ->method('getMultiple')
+                    ->willReturn([$this->key => $this->cacheMissValue]);
+
+        $this->cache->expects($this->never())
+                    ->method('setMultiple');
+
+        $this->cache->expects($this->never())
+                    ->method('clear');
+
+        $this->cache->expects($this->never())
+                    ->method('deleteMultiple');
+
+        $this->cache->expects($this->never())
+                    ->method('has');
+
+        $message = 'Woe is me.';
+        $code = 6626;
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage($message);
+        $this->expectExceptionCode($code);
+
+        $this->cacheAdapter->get(
+            $this->key,
+            function (CacheItem $cacheItem) use ($message, $code) {
+                $cacheItem->expiresAfter(5);
+
+                throw new LogicException($message, $code);
+            }
+        );
+    }
+}

--- a/src/test/CacheItemTest.php
+++ b/src/test/CacheItemTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace WebArch\BitrixCache\Test;
+
+use DateInterval;
+use DateTimeImmutable;
+use WebArch\BitrixCache\CacheItem;
+use WebArch\BitrixCache\Enum\ErrorCode;
+use WebArch\BitrixCache\Exception\InvalidArgumentException;
+use WebArch\BitrixCache\Test\Fixture\CacheItemFixture;
+
+class CacheItemTest extends CacheItemFixture
+{
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->setUpCacheItem();
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetMetadata(): void
+    {
+        $someMetadata = ['bar' => 'baz', 'foo' => 'test'];
+        $this->assertEqualsCanonicalizing(
+            $someMetadata,
+            $this->cacheItem->setMetadata($someMetadata)
+                            ->getMetadata()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpiresAtNull(): void
+    {
+        $this->cacheItem->expiresAt(null);
+        $this->assertNull($this->cacheItemExpiryProperty->getValue($this->cacheItem));
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpiresAtDateTime(): void
+    {
+        $expiresAt = new DateTimeImmutable();
+        $this->cacheItem->expiresAt($expiresAt);
+        $this->assertEquals(
+            $expiresAt->format('U.u'),
+            $this->cacheItemExpiryProperty->getValue($this->cacheItem)
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpiresAtInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ErrorCode::INVALID_EXPIRATION_DATE);
+        /**
+         * @noinspection PhpParamsInspection
+         * @phpstan-ignore-next-line
+         */
+        $this->cacheItem->expiresAt(false);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpiresAfterNull(): void
+    {
+        $this->cacheItem->expiresAfter(null);
+        $this->assertNull($this->cacheItemExpiryProperty->getValue($this->cacheItem));
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpiresAfterDateInterval(): void
+    {
+        $expiresAfter = new DateInterval('PT37S');
+        $this->cacheItem->expiresAfter($expiresAfter);
+        $this->assertEqualsWithDelta(
+            37.0 + microtime(true),
+            $this->cacheItemExpiryProperty->getValue($this->cacheItem),
+            0.1
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpiresAfterTime(): void
+    {
+        $expiresAfter = 23;
+        $this->cacheItem->expiresAfter($expiresAfter);
+        $this->assertEqualsWithDelta(
+            $expiresAfter + microtime(true),
+            $this->cacheItemExpiryProperty->getValue($this->cacheItem),
+            0.1
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpiresAfterInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ErrorCode::INVALID_EXPIRATION);
+        /** @phpstan-ignore-next-line */
+        $this->cacheItem->expiresAfter('invalid!');
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidateKeySuccess(): void
+    {
+        $cacheKey = 'AzaZ0-9.xxx';
+        $this->assertEquals($cacheKey, CacheItem::validateKey($cacheKey));
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidateKeyNonString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ErrorCode::INVALID_KEY_TYPE);
+        /** @phpstan-ignore-next-line */
+        CacheItem::validateKey(0);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidateKeyEmpty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ErrorCode::EMPTY_KEY);
+        CacheItem::validateKey('');
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidateKeyReservedChars(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(ErrorCode::RESERVED_CHARACTERS_IN_KEY);
+        CacheItem::validateKey('abc/xyz');
+    }
+}

--- a/src/test/Fixture/AntiStampedeCacheAdapterFixture.php
+++ b/src/test/Fixture/AntiStampedeCacheAdapterFixture.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace WebArch\BitrixCache\Test\Fixture;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClassConstant;
+use WebArch\BitrixCache\AntiStampedeCacheAdapter;
+use WebArch\BitrixCache\Cache;
+use WebArch\BitrixTaxidermist\Taxidermist;
+
+class AntiStampedeCacheAdapterFixture extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected $cachedValue = 'This is the cached value.';
+
+    /**
+     * @var string
+     */
+    protected $key = 'cacheKey';
+
+    /**
+     * @var string
+     */
+    protected $cachePath = '/path';
+
+    /**
+     * @var int
+     */
+    protected $cacheDefaultLifetime = 1234;
+
+    /**
+     * @var string
+     */
+    protected $cacheBaseDir = 'baseDir';
+
+    /**
+     * @var AntiStampedeCacheAdapter
+     */
+    protected $cacheAdapter;
+
+    /**
+     * @var Cache|MockObject
+     */
+    protected $cache;
+
+    /**
+     * @var string
+     */
+    protected $cacheMissValue;
+
+    /**
+     * @inheritDoc
+     */
+    public static function setUpBeforeClass(): void
+    {
+        (new Taxidermist())->taxidermizeAll();
+    }
+
+    /**
+     * @return void
+     */
+    protected function mockCache(): void
+    {
+        $this->cache = $this->getMockBuilder(Cache::class)
+                            ->onlyMethods(
+                                [
+                                    'clear',
+                                    'deleteMultiple',
+                                    'getMultiple',
+                                    'has',
+                                    'setMultiple',
+                                ]
+                            )
+                            ->getMock();
+    }
+
+    /**
+     * @return void
+     */
+    protected function setUpAntiStampedeCacheAdapter(): void
+    {
+        $this->cacheMissValue = (new ReflectionClassConstant(
+            AntiStampedeCacheAdapter::class,
+            'CACHE_MISS_VALUE'
+        ))->getValue();
+        $this->cacheAdapter = $this->getMockBuilder(AntiStampedeCacheAdapter::class)
+                                   ->setConstructorArgs(
+                                       [
+                                           $this->cachePath,
+                                           $this->cacheDefaultLifetime,
+                                           $this->cacheBaseDir,
+                                       ]
+                                   )
+                                   ->onlyMethods(['getCache'])
+                                   ->getMock();
+        $this->cacheAdapter->expects($this->any())
+                           ->method('getCache')
+                           ->willReturn($this->cache);
+    }
+}

--- a/src/test/Fixture/CacheItemFixture.php
+++ b/src/test/Fixture/CacheItemFixture.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WebArch\BitrixCache\Test\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use WebArch\BitrixCache\CacheItem;
+
+class CacheItemFixture extends TestCase
+{
+    /**
+     * @var CacheItem
+     */
+    protected $cacheItem;
+
+    /**
+     * @var ReflectionProperty
+     */
+    protected $cacheItemExpiryProperty;
+
+    /**
+     * @return void
+     */
+    protected function setUpCacheItem(): void
+    {
+        $this->cacheItem = (new CacheItem());
+        $this->cacheItemExpiryProperty = (new ReflectionProperty(CacheItem::class, 'expiry'));
+        $this->cacheItemExpiryProperty->setAccessible(true);
+    }
+}

--- a/src/test/LockRegistryTest.php
+++ b/src/test/LockRegistryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WebArch\BitrixCache\Test;
+
+use PHPUnit\Framework\TestCase;
+use WebArch\BitrixCache\LockRegistry;
+
+class LockRegistryTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testSetFiles(): void
+    {
+        $DS = DIRECTORY_SEPARATOR;
+        $previousSetFiles = LockRegistry::setFiles([]);
+        $this->assertEquals(
+            [realpath(__DIR__ . $DS . '..' . $DS . 'main' . $DS . 'AntiStampedeCacheAdapter.php')],
+            $previousSetFiles
+        );
+        $previousSetFiles = LockRegistry::setFiles($previousSetFiles);
+        $this->assertEquals(
+            [],
+            $previousSetFiles
+        );
+    }
+}


### PR DESCRIPTION
Добавлено:
- Адаптер `\WebArch\BitrixCache\AntiStampedeCacheAdapter` с двойной
  защитой от "давки в кеше"("cache stampede"; другое название -
  "собачья свалка", "dog piling") методами "блокировки"("locking")
  и "вероятностного преждевременного устаревания"("probabilistic
  early expiration"), адаптированными из Symfony Cache 5.1