### PR TITLE
fix: Exception в AntiStampedeCacheAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+1.6.1
+-----
+
+### Исправлено:
+- Создание `\WebArch\BitrixCache\AntiStampedeCacheAdapter` при использовании не `cacheenginememcache` приводило к ошибке
+    `InvalidArgumentException`
+
 1.6.0
 -----
 

--- a/src/main/Enum/ErrorCode.php
+++ b/src/main/Enum/ErrorCode.php
@@ -52,8 +52,6 @@ class ErrorCode
 
     const RESERVED_CHARACTERS_IN_TAG = 24;
 
-    const BASE_DIR_AND_PATH_ARE_TOO_LONG = 25;
-
     const INVALID_KEY_TYPE = 26;
 
     const RESERVED_CHARACTERS_IN_KEY = 27;

--- a/src/main/Traits/AbstractAdapterTrait.php
+++ b/src/main/Traits/AbstractAdapterTrait.php
@@ -57,6 +57,9 @@ trait AbstractAdapterTrait
 
     /**
      * @var null|int The maximum length to enforce for identifiers or null when no limit applies
+     *
+     * @deprecated Bitrix transforms baseDir, path and even the key in such way, it's impossible to perform any length
+     *     check on it.
      */
     protected $maxIdLength;
 
@@ -430,19 +433,6 @@ trait AbstractAdapterTrait
         CacheItem::validateKey($key);
         $this->ids[$key] = $key;
 
-        if (null === $this->maxIdLength) {
-            return $this->namespace . $this->namespaceVersion . $key;
-        }
-        if (strlen($id = $this->namespace . $this->namespaceVersion . $key) > $this->maxIdLength) {
-            // Use MD5 to favor speed over security, which is not an issue here
-            $this->ids[$key] = $id = substr_replace(
-                base64_encode(hash('md5', $key, true)),
-                static::NS_SEPARATOR,
-                -(strlen($this->namespaceVersion) + 2)
-            );
-            $id = $this->namespace . $this->namespaceVersion . $id;
-        }
-
-        return $id;
+        return $this->namespace . $this->namespaceVersion . $key;
     }
 }

--- a/src/test/Fixture/AntiStampedeCacheAdapterFixture.php
+++ b/src/test/Fixture/AntiStampedeCacheAdapterFixture.php
@@ -37,7 +37,7 @@ class AntiStampedeCacheAdapterFixture extends TestCase
     protected $cacheBaseDir = 'baseDir';
 
     /**
-     * @var AntiStampedeCacheAdapter
+     * @var AntiStampedeCacheAdapter|MockObject
      */
     protected $cacheAdapter;
 


### PR DESCRIPTION
Исправлено:
- Создание \WebArch\BitrixCache\AntiStampedeCacheAdapter при использовании не cacheenginememcache приводило к ошибке
  InvalidArgumentException