### PR TITLE
feat: Cache::clearByIblockTag()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+1.7.0
+-----
+
+### Добавлено:
+- Метод `\WebArch\BitrixCache\Cache::clearByIblockTag()`, очищающий кеш по тегу инфоблока 
+
 1.6.1
 -----
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Битрикс Кеш
 ===========
-[![Travis Build Status](https://travis-ci.org/webarchitect609/bitrix-cache.svg?branch=master)](https://travis-ci.org/webarchitect609/bitrix-cache)
+[![Travis Build Status](https://travis-ci.com/webarchitect609/bitrix-cache.svg?branch=master)](https://travis-ci.com/webarchitect609/bitrix-cache)
 [![Latest version](https://img.shields.io/github/v/tag/webarchitect609/bitrix-cache?sort=semver)](https://github.com/webarchitect609/bitrix-cache/releases)
 [![Downloads](https://img.shields.io/packagist/dt/webarchitect609/bitrix-cache)](https://packagist.org/packages/webarchitect609/bitrix-cache)
 [![PHP version](https://img.shields.io/packagist/php-v/webarchitect609/bitrix-cache)](https://www.php.net/supported-versions.php)

--- a/src/main/Cache.php
+++ b/src/main/Cache.php
@@ -184,6 +184,7 @@ class Cache implements CacheInterface
      *
      * @throws InvalidArgumentException Если в $key передано недопустимое значение.
      * @return mixed Значение из кеша или $default в случае "промаха".
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function get($key, $default = null)
     {
@@ -211,6 +212,7 @@ class Cache implements CacheInterface
      *
      * @throws InvalidArgumentException
      * @return bool true в случае успешной записи или false в случае, если кеш с таким ключом существует.
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function set($key, $value, $ttl = null)
     {
@@ -244,6 +246,7 @@ class Cache implements CacheInterface
      *
      * @throws InvalidArgumentException
      * @return bool true при успешном удалении или false при ошибке.
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function delete($key)
     {
@@ -285,6 +288,7 @@ class Cache implements CacheInterface
      *
      * @throws InvalidArgumentException
      * @return array<mixed>
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function getMultiple($keys, $default = null)
     {
@@ -306,6 +310,7 @@ class Cache implements CacheInterface
      *     используется значение по умолчанию.
      *
      * @return bool true в случае успеха или false в случае неудачи.
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function setMultiple($values, $ttl = null)
     {
@@ -326,6 +331,7 @@ class Cache implements CacheInterface
      *
      * @throws InvalidArgumentException
      * @return bool true в случае успеха или false в случае неудачи удаления хотя бы одного из ключей.
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function deleteMultiple($keys)
     {
@@ -352,6 +358,7 @@ class Cache implements CacheInterface
      * @throws InvalidArgumentException
      * @return bool
      *
+     * @noinspection PhpMissingParamTypeInspection
      */
     public function has($key)
     {
@@ -424,6 +431,17 @@ class Cache implements CacheInterface
     {
         $this->getBitrixTaggedCache()
              ->clearByTag($tag);
+    }
+
+    /**
+     * Сбрасывает кеш по тегу инфоблока.
+     *
+     * @param int $iblockId числовой идентификатор инфоблока.
+     */
+    public function clearByIblockTag(int $iblockId): void
+    {
+        $this->getBitrixTaggedCache()
+             ->clearByTag($this->createIblockTag($iblockId));
     }
 
     /**
@@ -614,7 +632,7 @@ class Cache implements CacheInterface
     public function addIblockTag(int $iblockId)
     {
         $this->assertIblockId($iblockId);
-        $this->addTag(self::TAG_PREFIX_IBLOCK_ID . $iblockId);
+        $this->addTag($this->createIblockTag($iblockId));
 
         return $this;
     }
@@ -694,6 +712,7 @@ class Cache implements CacheInterface
      * @param string $name
      *
      * @throws InvalidArgumentException
+     * @noinspection PhpMissingParamTypeInspection
      */
     private function assertKeys($keys, string $name): void
     {
@@ -895,5 +914,15 @@ class Cache implements CacheInterface
                 $exception
             );
         }
+    }
+
+    /**
+     * @param int $iblockId
+     *
+     * @return string
+     */
+    private function createIblockTag(int $iblockId): string
+    {
+        return self::TAG_PREFIX_IBLOCK_ID . $iblockId;
     }
 }

--- a/src/test/CacheTest.php
+++ b/src/test/CacheTest.php
@@ -465,6 +465,29 @@ class CacheTest extends CacheFixture
     /**
      * @return void
      */
+    public function testClearByIblockTag(): void
+    {
+        $this->setUpBitrixCacheIsNeverCalled();
+        $iblockId = 100500;
+        $tag = 'iblock_id_'.$iblockId;
+        $this->bitrixTaggedCache->expects($this->once())
+                                ->method('clearByTag')
+                                ->with($tag);
+        $this->bitrixTaggedCache->expects($this->never())
+                                ->method('abortTagCache');
+        $this->bitrixTaggedCache->expects($this->never())
+                                ->method('endTagCache');
+        $this->bitrixTaggedCache->expects($this->never())
+                                ->method('startTagCache');
+        $this->bitrixTaggedCache->expects($this->never())
+                                ->method('registerTag');
+
+        $this->cache->clearByIblockTag($iblockId);
+    }
+
+    /**
+     * @return void
+     */
     public function testSetTTLGetTTL()
     {
         $this->setUpBitrixCacheIsNeverCalled();


### PR DESCRIPTION
docs: Переход на travis-ci.com
Добавлено:
    - Метод \WebArch\BitrixCache\Cache::clearByIblockTag(), очищающий кеш по тегу инфоблока

