### PR TITLE
Feature/allow tags from closure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ os: linux
 dist: bionic
 language: php
 
+branches:
+  only:
+    - master
+    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
+
 git:
   depth: 10
   quiet: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,114 +1,145 @@
 Change Log
 ==========
 
+1.7.3
+-----
+
+### Изменено:
+
+- Замыкание, переданное в `\WebArch\BitrixCache\Cache::callback()`, теперь может установить теги кеша.
+
+1.7.2
+-----
+
+Изменений в клиентском коде нет. Исправлена интеграция с Travis CI: поддержка xDebug v3
+
 1.7.1
 -----
 
 ### Добавлено:
-- Возможность [финансово помочь развитию этой библиотеки через ЮMoney](https://sobe.ru/na/bitrix_cache) 
+
+- Возможность [финансово помочь развитию этой библиотеки через ЮMoney](https://sobe.ru/na/bitrix_cache)
 
 1.7.0
 -----
 
 ### Добавлено:
-- Метод `\WebArch\BitrixCache\Cache::clearByIblockTag()`, очищающий кеш по тегу инфоблока 
+
+- Метод `\WebArch\BitrixCache\Cache::clearByIblockTag()`, очищающий кеш по тегу инфоблока
 
 1.6.1
 -----
 
 ### Исправлено:
+
 - Создание `\WebArch\BitrixCache\AntiStampedeCacheAdapter` при использовании не `cacheenginememcache` приводило к ошибке
-    `InvalidArgumentException`
+  `InvalidArgumentException`
 
 1.6.0
 -----
 
 ### Добавлено:
+
 - Адаптер `\WebArch\BitrixCache\AntiStampedeCacheAdapter` с двойной защитой от
-    ["давки в кеше"](https://en.wikipedia.org/wiki/Cache_stampede) ("cache stampede"; другое название - "собачья
-    свалка", "dog piling") методами "блокировки"("locking") и "вероятностного преждевременного
-    устаревания"("probabilistic early expiration"), адаптированными из
-    [Symfony Cache 5.1](https://symfony.com/doc/5.1/components/cache.html)
+  ["давки в кеше"](https://en.wikipedia.org/wiki/Cache_stampede) ("cache stampede"; другое название - "собачья свалка"
+  , "dog piling") методами "блокировки"("locking") и "вероятностного преждевременного устаревания"("probabilistic early
+  expiration"), адаптированными из
+  [Symfony Cache 5.1](https://symfony.com/doc/5.1/components/cache.html)
 
 ### Изменено:
+
 - Класс `\WebArch\BitrixCache\BitrixCache` игнорируется при составлении coverage отчёта
 
 1.5.1
 -----
 
 ### Добавлено:
+
 - Тесты: команда `composer check:all` для выполнения всех проверок сразу: code-style, статический анализ кода, unit
-    тесты и проверка безопасности используемых пакетов/библиотек.
+  тесты и проверка безопасности используемых пакетов/библиотек.
 
 1.5.0
 -----
 
 ### Добавлено:
+
 - Метод `\WebArch\BitrixCache\Cache::setPathByClass()`, которым можно удобно выставлять `$path` по имени любого класса.
 
 1.4.5
 -----
 
 ### Исправлено:
+
 - Метод `\WebArch\BitrixCache\Cache::set()` больше не перезаписывает существующий кеш, а возвращает `false`
 
 1.4.4
 -----
 
 ### Исправлено:
+
 - Вложенное кеширование замыканий приводило к некорректной записи кеша из-за того, что экземпляр
-    `\Bitrix\Main\Data\Cache` хранился в статическом свойстве.
+  `\Bitrix\Main\Data\Cache` хранился в статическом свойстве.
 
 ### Изменено:
+
 - Сообщение об исключении в замыкании содержит больше информации для использования в системах, не поддерживающих
-    exception chaining.
+  exception chaining.
 
 1.4.3
 -----
 
 ### Добавлено
+
 - Тесты: автоматизация статического анализа кода и code style
 
 ### Изменено
+
 - Исключение из релиза файлов и папок, необходимых для разработки
 
 ### Исправлено
+
 - Исправление всех ошибок, найденных статическим анализатором [PHPStan](https://phpstan.org)
 
 1.4.2
 -----
 
 ### Изменено:
-- Обновление `webarchitect609/bitrix-taxidermist` до `^0.1` 
+
+- Обновление `webarchitect609/bitrix-taxidermist` до `^0.1`
 
 1.4.1
 -----
 
 ### Изменено:
+
 - Применена библиотека `webarchitect609/bitrix-taxidermist` для изготовления имитаций Битриксовых классов
 
 1.4.0
 -----
 
 ### Добавлено:
-- Новая версия работы с кешем `\WebArch\BitrixCache\Cache`, которая используется на версии 2.0. Подробнее 
-    смотрите в [инструкции по обновлению](UPGRADING.md)
+
+- Новая версия работы с кешем `\WebArch\BitrixCache\Cache`, которая используется на версии 2.0. Подробнее смотрите
+  в [инструкции по обновлению](UPGRADING.md)
 - 100% покрытие `\WebArch\BitrixCache\Cache` Unit-тестами
 - Добавлена поддержка PHP Coding Standards Fixer с интеграцией с PhpStorm
 
 ### Изменено:
+
 - Лицензионное соглашение изменено на [BSD-3-Clause](LICENSE.md)
 
 ### Устарело:
-- Класс `\WebArch\BitrixCache\BitrixCache` помечен полностью устаревшим и будет удалён в версии 2.0. Подробнее
-    смотрите в [инструкции по обновлению](UPGRADING.md)
+
+- Класс `\WebArch\BitrixCache\BitrixCache` помечен полностью устаревшим и будет удалён в версии 2.0. Подробнее смотрите
+  в [инструкции по обновлению](UPGRADING.md)
 
 ### Удалено:
+
 - PHP ^5.5 и <= 7.1 больше не поддерживаются
 
 ### Безопасность:
-- Добавлено использование [Roave Security Advisories](https://packagist.org/packages/roave/security-advisories)
 
+- Добавлено использование [Roave Security Advisories](https://packagist.org/packages/roave/security-advisories)
 
 1.3.0
 -----
@@ -129,10 +160,9 @@ Change Log
 
 **Повышение удобства**
 
-Новый метод BitrixCache::callback() возвращает строго тоже самое, что возвращается из кешируемого замыкания, 
-а не только массив, что упрощает работу при кешировании объектов или примитивных типов;
-Уточнено требование к версии php: ^5.5 | ^7.1;
-Помечены устаревшими и будут удалены с версии 2.0 все setter-методы в BitrixCache, начинающиеся с 'with*';
-Добавлены setter-методы в BitrixCache, начинающиеся с 'set*', для замены устаревших;
-Помечены устаревшими и будут удалены с версии 2.0 методы BitrixCache::resultOf() и BitrixCache::execute();
-Добавлены методы BitrixCache::callback() и BitrixCache::executeCallback() для замены устаревших;
+Новый метод BitrixCache::callback() возвращает строго тоже самое, что возвращается из кешируемого замыкания, а не только
+массив, что упрощает работу при кешировании объектов или примитивных типов; Уточнено требование к версии php: ^5.5 |
+^7.1; Помечены устаревшими и будут удалены с версии 2.0 все setter-методы в BitrixCache, начинающиеся с 'with*';
+Добавлены setter-методы в BitrixCache, начинающиеся с 'set*', для замены устаревших; Помечены устаревшими и будут
+удалены с версии 2.0 методы BitrixCache::resultOf() и BitrixCache::execute(); Добавлены методы BitrixCache::callback() и
+BitrixCache::executeCallback() для замены устаревших;

--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@
                        }
                    );
     ```
+
+    Тег кеша также можно установить внутри замыкания:
+
+    ```php
+    use WebArch\BitrixCache\Cache;
+    
+    $cache = Cache::create();
+    $result = $cache->callback(
+                        function () use($cache) {
+                            $cache->addTag('closureTag');
+
+                            return date(DATE_ISO8601);
+                        }
+                    );
+    ```
+
 5. Удаление тегированного кеша.
     
     Кеш из предыдущего примера может быть очищен по тегу. Важно, что при очистке по тегу не требуется устанавливать
@@ -274,6 +290,7 @@
     Дополнительная информация описана в документации компонента
     [Symfony Cache](https://symfony.com/doc/5.1/components/cache.html#cache-component-contracts) и соглашения
     [Cache Contracts](https://symfony.com/doc/5.1/components/cache.html#cache-component-contracts).
+
 
 Известные особенности
 ---------------------


### PR DESCRIPTION
Изменено:

- Замыкание, переданное в `\WebArch\BitrixCache\Cache::callback()`, теперь может установить теги кеша.