### PR TITLE
fix: Слишком мало конкурирующих запросов

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 Change Log
 ==========
 
+1.9.2
+-----
+
+### Исправлено:
+
+- по умолчанию в `\WebArch\BitrixCache\LockRegistry` был доступен только один конкурирующий запрос, а теперь 12.
+
 1.9.1
 -----
 
 ### Исправлено:
+
 - формально некорректные вызовы `set_error_handler()` в `\WebArch\BitrixCache\LockRegistry::open()` и
   `\WebArch\BitrixCache\Test\CacheItemTest::testNoLoggerTriggersUserWarning()`;
 - поддержка `PHP ^8.0`

--- a/src/main/LockRegistry.php
+++ b/src/main/LockRegistry.php
@@ -33,7 +33,19 @@ final class LockRegistry
      * @var array<string> The number of items in this list controls the max number of concurrent processes.
      */
     private static $files = [
+        __DIR__ . DIRECTORY_SEPARATOR . 'Traits/ContractsTrait.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'Traits/AbstractAdapterTrait.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'Enum/ErrorCode.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'Enum/CacheEngineType.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'Exception/RuntimeException.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'Exception/InvalidArgumentException.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'Exception/BadMethodCallException.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'Exception/LogicException.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'Cache.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'LockRegistry.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'CacheItem.php',
         __DIR__ . DIRECTORY_SEPARATOR . 'AntiStampedeCacheAdapter.php',
+        __DIR__ . DIRECTORY_SEPARATOR . 'BitrixCache.php',
     ];
 
     /**

--- a/src/test/LockRegistryTest.php
+++ b/src/test/LockRegistryTest.php
@@ -3,25 +3,81 @@
 namespace WebArch\BitrixCache\Test;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use WebArch\BitrixCache\LockRegistry;
 
 class LockRegistryTest extends TestCase
 {
     /**
+     * @var ReflectionProperty
+     */
+    private static $filesReflectionProperty;
+
+    /**
+     * @var mixed
+     */
+    private static $filesDefaultValue;
+
+    /**
+     * @inheritDoc
+     */
+    public static function setUpBeforeClass(): void
+    {
+        self::$filesReflectionProperty = new ReflectionProperty(LockRegistry::class, 'files');
+        self::$filesReflectionProperty->setAccessible(true);
+        self::$filesDefaultValue = self::$filesReflectionProperty->getValue();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        // Восстановить исходное значение в LockRegistry::$files
+        self::$filesReflectionProperty->setValue(self::$filesDefaultValue);
+    }
+
+    /**
      * @return void
      */
     public function testSetFiles(): void
     {
-        $DS = DIRECTORY_SEPARATOR;
         $previousSetFiles = LockRegistry::setFiles([]);
-        $this->assertEquals(
-            [realpath(__DIR__ . $DS . '..' . $DS . 'main' . $DS . 'AntiStampedeCacheAdapter.php')],
-            $previousSetFiles
-        );
+        $this->assertIsArray($previousSetFiles);
+        $this->assertNotEmpty($previousSetFiles);
         $previousSetFiles = LockRegistry::setFiles($previousSetFiles);
         $this->assertEquals(
             [],
             $previousSetFiles
         );
+    }
+
+    /**
+     * Проверяет, что все файлы, заданные по умолчанию в \WebArch\BitrixCache\LockRegistry::$files, существуют.
+     *
+     * @return void
+     */
+    public function testAllDefaultFilesExist(): void
+    {
+        $files = self::$filesReflectionProperty->getValue();
+        $this->assertIsArray($files, 'Files is array.');
+        $this->assertNotEmpty($files, 'There is any filename.');
+
+        foreach ($files as $file) {
+            $this->assertTrue(
+                is_file($file),
+                sprintf(
+                    'File %s is a file',
+                    $file
+                )
+            );
+            $this->assertFalse(
+                is_dir($file),
+                sprintf(
+                    'File %s is a file',
+                    $file
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
Исправлено:

- по умолчанию в `\WebArch\BitrixCache\LockRegistry` был доступен только
  один конкурирующий запрос, а теперь 12.