### PR TITLE
noOutput option to disable buffering

### DIFF
--- a/src/main/Cache.php
+++ b/src/main/Cache.php
@@ -936,6 +936,7 @@ class Cache implements CacheInterface
             if (is_null($this->bitrixCache)) {
                 $this->bitrixCache = $this->getBitrixApplication()
                                           ->getCache();
+                $this->bitrixCache->noOutput();
             }
 
             return $this->bitrixCache;


### PR DESCRIPTION
Битриксовый метод startDataCache открывает буферизацию ob_start();
в случае если callback выполнится с ошибкой, исключение пробросится наружу и буферизация, закрывающаяся в endDataCache не выполнится. 

Битриксовый метод noOutput включает флажок, игнорирующий всю работу с буферами, наверное разработчикам битрикса также захотелось хранить в кеше только данные, без html-вывода))
 
