### PR TITLE
fix: не отключена буферизация вывода

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+1.11.2
+------
+
+### Исправлено:
+
+- Не отключалась буферизация вывода, из-за чего в случае исключения в `callback` могла возникнуть
+  ошибка `[ErrorException] ob_start(): Cannot use output buffering in output buffering display handlers`.
+
 1.11.1
 ------
 

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,11 @@
     "symfony/polyfill-php80": "^1.18"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.0",
-    "phpstan/phpstan": "^0.12",
-    "phpunit/phpunit": "^8.5",
+    "friendsofphp/php-cs-fixer": "^3.4",
+    "phpstan/phpstan": "1.10",
+    "phpunit/phpunit": "^9.6",
     "roave/security-advisories": "dev-master",
-    "webarchitect609/bitrix-taxidermist": "^0.1"
+    "webarchitect609/bitrix-taxidermist": "^0.2.0"
   },
   "autoload": {
     "psr-4": {
@@ -58,9 +58,9 @@
       "@check:test",
       "@check:security"
     ],
-    "check:analyse": "vendor/bin/phpstan analyse --ansi --no-progress",
+    "check:analyse": "vendor/bin/phpstan analyse --ansi --no-progress --xdebug",
     "check:code-style": "vendor/bin/php-cs-fixer fix --ansi --dry-run --diff",
-    "check:security": "@composer update --no-suggest --no-interaction --dry-run roave/security-advisories",
+    "check:security": "@composer update --no-interaction --dry-run roave/security-advisories",
     "check:test": "vendor/bin/phpunit --colors=always"
   },
   "scripts-descriptions": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 parameters:
     level: 6 # from 0 to 8, or 'max' as an alias for the highest level
+    treatPhpDocTypesAsCertain: false
     paths:
         - src/main
         - src/test

--- a/src/main/AntiStampedeCacheAdapter.php
+++ b/src/main/AntiStampedeCacheAdapter.php
@@ -140,9 +140,7 @@ class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface
             if (true === $e) {
                 continue;
             }
-            /** @phpstan-ignore-next-line */
             if (is_array($e) || 1 === count($values)) {
-                /** @phpstan-ignore-next-line */
                 foreach (is_array($e) ? $e : array_keys($values) as $id) {
                     $ok = false;
                     $v = $values[$id];

--- a/src/main/Cache.php
+++ b/src/main/Cache.php
@@ -174,7 +174,6 @@ class Cache implements CacheInterface
                 throw $exception;
             }
             // Условие может измениться при вызове abort() в кешируемом callback
-            /** @noinspection PhpConditionAlreadyCheckedInspection */
             if (false === $this->closureAbortedCache) {
                 $this->startTagCache();
                 $this->endTagCache();
@@ -201,7 +200,7 @@ class Cache implements CacheInterface
      * Возвращает значение из кеша.
      *
      * @param string $key Уникальный идентификатор закешированного значения.
-     * @param mixed $default Значение по умолчанию, которое будет возвращено, если значение отсутствует в кеше.
+     * @param mixed  $default Значение по умолчанию, которое будет возвращено, если значение отсутствует в кеше.
      *
      * @throws InvalidArgumentException Если в $key передано недопустимое значение.
      * @return mixed Значение из кеша или $default в случае "промаха".
@@ -226,8 +225,8 @@ class Cache implements CacheInterface
     /**
      * Сохраняет значение в кеше под уникальным идентификатором с необязательным параметром временем жизни.
      *
-     * @param string $key Уникальный идентификатор закешированного значения.
-     * @param mixed $value Значение для кеширования, которое должно поддерживать сериализацию.
+     * @param string                $key Уникальный идентификатор закешированного значения.
+     * @param mixed                 $value Значение для кеширования, которое должно поддерживать сериализацию.
      * @param null|DateInterval|int $ttl Необязательный параметр. Время жизни кешируемого значения. Если не передан,
      *     используется значение по умолчанию.
      *
@@ -308,7 +307,7 @@ class Cache implements CacheInterface
      * Возвращает множество кешированных значений по множеству уникальных идентификаторов.
      *
      * @param array<string> $keys Множество уникальных идентификаторов.
-     * @param null|mixed $default Значение по умолчанию, которое будет возвращено, если значение отсутствует в кеше.
+     * @param null|mixed    $default Значение по умолчанию, которое будет возвращено, если значение отсутствует в кеше.
      *
      * @throws InvalidArgumentException
      * @return array<mixed>
@@ -330,7 +329,7 @@ class Cache implements CacheInterface
     /**
      * Сохраняет множество пар ключ => значение в кеше с необязательным параметром времени жизни.
      *
-     * @param array<string, mixed> $values Множество пар ключ => значение.
+     * @param array<string, mixed>  $values Множество пар ключ => значение.
      * @param null|DateInterval|int $ttl Необязательный параметр. Время жизни кешируемого значения. Если не передан,
      *     используется значение по умолчанию.
      *
@@ -769,7 +768,7 @@ class Cache implements CacheInterface
     /**
      * @param array<string> $keys
      *
-     * @param string $name
+     * @param string        $name
      *
      * @throws InvalidArgumentException
      * @noinspection PhpMissingParamTypeInspection
@@ -936,6 +935,7 @@ class Cache implements CacheInterface
             if (is_null($this->bitrixCache)) {
                 $this->bitrixCache = $this->getBitrixApplication()
                                           ->getCache();
+                $this->bitrixCache->noOutput();
             }
 
             return $this->bitrixCache;

--- a/src/main/LockRegistry.php
+++ b/src/main/LockRegistry.php
@@ -61,7 +61,6 @@ final class LockRegistry
         self::$files = $files;
 
         foreach (self::$openedFiles as $file) {
-            /** @phpstan-ignore-next-line */
             if ($file) {
                 flock($file, LOCK_UN);
                 fclose($file);
@@ -95,7 +94,6 @@ final class LockRegistry
     ) {
         $key = self::$files ? crc32($item->getKey()) % count(self::$files) : -1;
 
-        /** @phpstan-ignore-next-line */
         if ($key < 0 || (self::$lockedFiles[$key] ?? false) || !$lock = self::open($key)) {
             return $callback($item, $save);
         }

--- a/src/test/AntiStampedeCacheAdapterTest.php
+++ b/src/test/AntiStampedeCacheAdapterTest.php
@@ -182,6 +182,10 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
                     ->method('getMultiple')
                     ->willReturn([$this->key => $this->cacheMissValue]);
 
+        $this->cache->expects($this->exactly(2))
+                    ->method('addTag')
+                    ->willReturnSelf();
+
         $this->cache->expects($this->once())
                     ->method('set');
 
@@ -193,16 +197,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
 
         $this->cache->expects($this->never())
                     ->method('has');
-
-        $this->cache->expects($this->at(++$callCount))
-                    ->method('addTag')
-                    ->with($tag1)
-                    ->willReturnSelf();
-
-        $this->cache->expects($this->at(++$callCount))
-                    ->method('addTag')
-                    ->with($tag2)
-                    ->willReturnSelf();
 
         $value = $this->cacheAdapter->get(
             $this->key,
@@ -223,8 +217,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
      */
     public function testGetWithTagHits(): void
     {
-        $tag = 'fooCacheTag';
-
         $this->cache->expects($this->once())
                     ->method('getMultiple')
                     ->willReturn([$this->key => $this->cachedValue]);
@@ -246,9 +238,9 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
 
         $value = $this->cacheAdapter->get(
             $this->key,
-            function (CacheItem $cacheItem) use ($tag) {
+            function (CacheItem $cacheItem) {
                 $cacheItem->expiresAfter(60)
-                          ->tag($tag);
+                          ->tag('fooCacheTag');
 
                 throw new CommonLogicException('This closure should not be called, if the cache hits!');
             }

--- a/src/test/CacheTest.php
+++ b/src/test/CacheTest.php
@@ -150,9 +150,7 @@ class CacheTest extends CacheFixture
             return $this->cachedValue;
         };
         $this->setUpCallbackKey();
-        $atCountBitrixCache = 0;
-        $atCountBitrixTaggedCache = 0;
-        $this->bitrixCache->expects($this->at($atCountBitrixCache++))
+        $this->bitrixCache->expects($this->once())
                           ->method('startDataCache')
                           ->with(
                               Cache::DEFAULT_TTL,
@@ -163,18 +161,18 @@ class CacheTest extends CacheFixture
                           )
                           ->willReturn(true);
 
-        $this->bitrixTaggedCache->expects($this->at($atCountBitrixTaggedCache++))
+        $this->bitrixTaggedCache->expects($this->once())
                                 ->method('startTagCache')
                                 ->with(Cache::DEFAULT_PATH);
 
-        $this->bitrixTaggedCache->expects($this->at($atCountBitrixTaggedCache++))
+        $this->bitrixTaggedCache->expects($this->once())
                                 ->method('registerTag')
                                 ->with($tag);
 
-        $this->bitrixTaggedCache->expects($this->at($atCountBitrixTaggedCache))
+        $this->bitrixTaggedCache->expects($this->once())
                                 ->method('endTagCache');
 
-        $this->bitrixCache->expects($this->at($atCountBitrixCache))
+        $this->bitrixCache->expects($this->once())
                           ->method('endDataCache')
                           ->with([$this->resultKey => $this->cachedValue]);
 
@@ -558,9 +556,9 @@ class CacheTest extends CacheFixture
      */
     public function testTaggedCache()
     {
-        $atCountBitrixCache = 0;
-        $atCountBitrixTaggedCache = 0;
-        $this->bitrixCache->expects($this->at($atCountBitrixCache++))
+        $tag = 'baz';
+
+        $this->bitrixCache->expects($this->once())
                           ->method('startDataCache')
                           ->with(
                               Cache::DEFAULT_TTL,
@@ -571,23 +569,23 @@ class CacheTest extends CacheFixture
                           )
                           ->willReturn(true);
 
-        $this->bitrixTaggedCache->expects($this->at($atCountBitrixTaggedCache++))
+        $this->bitrixTaggedCache->expects($this->once())
                                 ->method('startTagCache')
                                 ->with(Cache::DEFAULT_PATH);
 
-        $this->bitrixTaggedCache->expects($this->at($atCountBitrixTaggedCache++))
+        $this->bitrixTaggedCache->expects($this->exactly(2))
                                 ->method('registerTag')
-                                ->with('iblock_id_1');
+                                ->willReturnMap(
+                                    [
+                                        ['iblock_id_1', null],
+                                        [$tag, null],
+                                    ]
+                                );
 
-        $tag = 'baz';
-        $this->bitrixTaggedCache->expects($this->at($atCountBitrixTaggedCache++))
-                                ->method('registerTag')
-                                ->with($tag);
-
-        $this->bitrixTaggedCache->expects($this->at($atCountBitrixTaggedCache))
+        $this->bitrixTaggedCache->expects($this->once())
                                 ->method('endTagCache');
 
-        $this->bitrixCache->expects($this->at($atCountBitrixCache))
+        $this->bitrixCache->expects($this->once())
                           ->method('endDataCache')
                           ->with([$this->resultKey => $this->cachedValue]);
 
@@ -704,7 +702,7 @@ class CacheTest extends CacheFixture
     }
 
     /**
-     * @return array<string, array>
+     * @return array<string, array<int>>
      */
     public function incorrectTTLDataProvider(): array
     {
@@ -788,7 +786,7 @@ class CacheTest extends CacheFixture
     }
 
     /**
-     * @return array<array>
+     * @return array<array<DateTimeImmutable>>
      */
     public function incorrectExpirationTimeDataProvider(): array
     {
@@ -919,7 +917,7 @@ class CacheTest extends CacheFixture
     }
 
     /**
-     * @return array<array>
+     * @return array<array<string>>
      */
     public function incorrectBaseDirDataProvider(): array
     {
@@ -1000,7 +998,7 @@ class CacheTest extends CacheFixture
     }
 
     /**
-     * @return array<string, array>
+     * @return array<string, array<int>>
      */
     public function invalidIblockIdDataProvider(): array
     {
@@ -1034,7 +1032,7 @@ class CacheTest extends CacheFixture
     }
 
     /**
-     * @return array<array>
+     * @return array<array<null|DateInterval|int>>
      */
     public function mixedTTLDataProvider(): array
     {


### PR DESCRIPTION
Исправлено:

- Не отключалась буферизация вывода, из-за чего в случае исключения в callback могла возникнуть ошибка [ErrorException] ob_start(): Cannot use output buffering in output buffering display handlers.