### PR TITLE
Обновление зависимостей, поддержка php 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
     }
   ],
   "require": {
-    "php": "^7.2 || ^8.0",
-    "psr/cache": "^1.0",
-    "psr/log": "^1.1",
-    "psr/simple-cache": "^1.0",
+    "php": "^8.0",
+    "psr/cache": "^1 || ^2 || ^3",
+    "psr/log": "^1 || ^2 || ^3",
+    "psr/simple-cache": "^1 || ^2 || ^3",
     "symfony/contracts": "^1.1.8 || ^2.0 || ^3.0",
     "symfony/polyfill-php80": "^1.18"
   },

--- a/src/main/AntiStampedeCacheAdapter.php
+++ b/src/main/AntiStampedeCacheAdapter.php
@@ -117,11 +117,8 @@ class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface
 
     /**
      * @inheritDoc
-     *
-     * @return bool
-     * @noinspection PhpMissingReturnTypeInspection
      */
-    public function commit()
+    public function commit(): bool
     {
         $ok = true;
         $byLifetime = $this->mergeByLifetime;
@@ -140,8 +137,8 @@ class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface
             if (true === $e) {
                 continue;
             }
-            if (is_array($e) || 1 === count($values)) {
-                foreach (is_array($e) ? $e : array_keys($values) as $id) {
+            if (1 === count($values)) {
+                foreach (array_keys($values) as $id) {
                     $ok = false;
                     $v = $values[$id];
                     $type = get_debug_type($v);
@@ -154,7 +151,7 @@ class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface
                         $this->logger,
                         $message,
                         [
-                            'key'           => substr($id, strlen($this->namespace)),
+                            'key'           => substr($id, strlen($this->namespace ?? '')),
                             'exception'     => $e instanceof Exception ? $e : null,
                             'cache-adapter' => get_debug_type($this),
                         ]
@@ -209,9 +206,8 @@ class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface
      * @param array<string, mixed> $values
      *
      * @return bool
-     * @noinspection PhpMissingReturnTypeInspection
      */
-    protected function doSave(array $values, int $lifetime)
+    protected function doSave(array $values, int $lifetime): bool
     {
         $result = 1;
         foreach ($values as $key => $value) {
@@ -234,9 +230,8 @@ class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface
      * @inheritDoc
      *
      * @return bool
-     * @noinspection PhpMissingReturnTypeInspection
      */
-    protected function doHave(string $id)
+    protected function doHave(string $id): bool
     {
         return $this->getCache()->has($id);
     }
@@ -247,9 +242,8 @@ class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface
      * @param array<string> $ids
      *
      * @return array<string, mixed>
-     * @noinspection PhpMissingReturnTypeInspection
      */
-    protected function doFetch(array $ids)
+    protected function doFetch(array $ids): array
     {
         $result = [];
         foreach ($this->getCache()->getMultiple($ids, self::CACHE_MISS_VALUE) as $key => $value) {
@@ -268,9 +262,8 @@ class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface
      * @param array<string> $ids
      *
      * @return bool
-     * @noinspection PhpMissingReturnTypeInspection
      */
-    protected function doDelete(array $ids)
+    protected function doDelete(array $ids): bool
     {
         return $this->getCache()->deleteMultiple($ids);
     }
@@ -279,16 +272,12 @@ class AntiStampedeCacheAdapter implements CacheInterface, CacheItemPoolInterface
      * @inheritDoc
      *
      * @return bool
-     * @noinspection PhpMissingReturnTypeInspection
      */
-    protected function doClear(string $namespace)
+    protected function doClear(string $namespace): bool
     {
         return $this->getCache()->clear();
     }
 
-    /**
-     * @return Cache
-     */
     protected function getCache(): Cache
     {
         return Cache::create()

--- a/src/main/Cache.php
+++ b/src/main/Cache.php
@@ -206,7 +206,7 @@ class Cache implements CacheInterface
      * @return mixed Значение из кеша или $default в случае "промаха".
      * @noinspection PhpMissingParamTypeInspection
      */
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         $this->setKey($key);
         $initCache = $this->getBitrixCache()->initCache(
@@ -235,7 +235,7 @@ class Cache implements CacheInterface
      * @noinspection PhpMissingParamTypeInspection
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function set($key, $value, $ttl = null)
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
     {
         $this->setKey($key)
              ->setMixedTTL($ttl);
@@ -270,7 +270,7 @@ class Cache implements CacheInterface
      * @noinspection PhpMissingParamTypeInspection
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function delete($key)
+    public function delete(string $key): bool
     {
         $this->setKey($key);
         $initCache = $this->getBitrixCache()->initCache(
@@ -295,7 +295,7 @@ class Cache implements CacheInterface
      * @return bool true при успешной очистке или false при ошибке.
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function clear()
+    public function clear(): bool
     {
         $this->getBitrixCache()
              ->cleanDir($this->getPath(), $this->getBaseDir());
@@ -314,7 +314,7 @@ class Cache implements CacheInterface
      * @noinspection PhpMissingParamTypeInspection
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         $this->assertKeys($keys, 'Keys');
 
@@ -337,7 +337,7 @@ class Cache implements CacheInterface
      * @noinspection PhpMissingParamTypeInspection
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
     {
         $this->assertKeys($values, 'Values');
         $result = 1;
@@ -358,7 +358,7 @@ class Cache implements CacheInterface
      * @noinspection PhpMissingParamTypeInspection
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple(iterable $keys): bool
     {
         $this->assertKeys($keys, 'Keys');
         $result = 1;
@@ -385,7 +385,7 @@ class Cache implements CacheInterface
      * @noinspection PhpMissingParamTypeInspection
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function has($key)
+    public function has(string $key): bool
     {
         $this->setKey($key);
 

--- a/src/main/CacheItem.php
+++ b/src/main/CacheItem.php
@@ -64,7 +64,7 @@ final class CacheItem implements ItemInterface
     /**
      * {@inheritdoc}
      */
-    public function get()
+    public function get(): mixed
     {
         return $this->value;
     }
@@ -82,7 +82,7 @@ final class CacheItem implements ItemInterface
      *
      * @return $this
      */
-    public function set($value): self
+    public function set(mixed $value): static
     {
         $this->value = $value;
 
@@ -94,20 +94,12 @@ final class CacheItem implements ItemInterface
      *
      * @return $this
      */
-    public function expiresAt($expiration): self
+    public function expiresAt(?\DateTimeInterface $expiration): static
     {
         if (null === $expiration) {
             $this->expiry = null;
-        } elseif ($expiration instanceof DateTimeInterface) {
-            $this->expiry = (float)$expiration->format('U.u');
         } else {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expiration date must implement DateTimeInterface or be null, "%s" given.',
-                    get_debug_type($expiration)
-                ),
-                ErrorCode::INVALID_EXPIRATION_DATE
-            );
+            $this->expiry = (float)$expiration->format('U.u');
         }
 
         return $this;
@@ -118,7 +110,7 @@ final class CacheItem implements ItemInterface
      *
      * @return $this
      */
-    public function expiresAfter($time): self
+    public function expiresAfter(int|\DateInterval|null $time): static
     {
         if (null === $time) {
             $this->expiry = null;
@@ -127,14 +119,6 @@ final class CacheItem implements ItemInterface
                 + (float)DateTime::createFromFormat('U', '0')->add($time)->format('U.u');
         } elseif (is_int($time)) {
             $this->expiry = $time + microtime(true);
-        } else {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Expiration date must be an integer, a DateInterval or null, "%s" given.',
-                    get_debug_type($time)
-                ),
-                ErrorCode::INVALID_EXPIRATION
-            );
         }
 
         return $this;
@@ -143,7 +127,7 @@ final class CacheItem implements ItemInterface
     /**
      * {@inheritdoc}
      */
-    public function tag($tags): ItemInterface
+    public function tag($tags): static
     {
         if (!$this->isTaggable) {
             throw new LogicException(

--- a/src/main/LockRegistry.php
+++ b/src/main/LockRegistry.php
@@ -79,7 +79,6 @@ final class LockRegistry
      * @param null|Closure $setMetadata
      * @param null|LoggerInterface $logger
      *
-     * @phpstan-ignore-next-line
      * @throws PsrCacheInvalidArgumentException
      * @throws Exception
      * @return null|mixed

--- a/src/main/Traits/AbstractAdapterTrait.php
+++ b/src/main/Traits/AbstractAdapterTrait.php
@@ -124,7 +124,7 @@ trait AbstractAdapterTrait
      * @return bool
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function hasItem($key)
+    public function hasItem(string $key): bool
     {
         $id = $this->getId($key);
 
@@ -151,7 +151,7 @@ trait AbstractAdapterTrait
      * @return bool
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function clear(string $prefix = '')
+    public function clear(string $prefix = ''): bool
     {
         $this->deferred = [];
         if ($cleared = $this->versioningIsEnabled) {
@@ -195,7 +195,7 @@ trait AbstractAdapterTrait
      * @return bool
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function deleteItem($key)
+    public function deleteItem(string $key): bool
     {
         return $this->deleteItems([$key]);
     }
@@ -206,7 +206,7 @@ trait AbstractAdapterTrait
      * @return bool
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function deleteItems(array $keys)
+    public function deleteItems(array $keys): bool
     {
         $ids = [];
 
@@ -248,7 +248,7 @@ trait AbstractAdapterTrait
     /**
      * {@inheritdoc}
      */
-    public function getItem($key)
+    public function getItem(string $key): CacheItemInterface
     {
         if ($this->deferred) {
             $this->commit();
@@ -279,9 +279,8 @@ trait AbstractAdapterTrait
     /**
      * {@inheritdoc}
      * @return iterable<string, mixed>
-     * @noinspection PhpMissingReturnTypeInspection
      */
-    public function getItems(array $keys = [])
+    public function getItems(array $keys = []): iterable
     {
         if ($this->deferred) {
             $this->commit();
@@ -312,7 +311,7 @@ trait AbstractAdapterTrait
      * @return bool
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
         if (!$item instanceof CacheItem) {
             return false;
@@ -342,7 +341,7 @@ trait AbstractAdapterTrait
      * @return bool
      * @noinspection PhpMissingReturnTypeInspection
      */
-    public function saveDeferred(CacheItemInterface $item)
+    public function saveDeferred(CacheItemInterface $item): bool
     {
         if (!$item instanceof CacheItem) {
             return false;
@@ -387,7 +386,7 @@ trait AbstractAdapterTrait
         $this->ids = [];
     }
 
-    public function __sleep()
+    public function __sleep(): array
     {
         throw new BadMethodCallException('Cannot serialize ' . __CLASS__);
     }

--- a/src/test/AntiStampedeCacheAdapterTest.php
+++ b/src/test/AntiStampedeCacheAdapterTest.php
@@ -23,7 +23,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
     }
 
     /**
-     * @phpstan-ignore-next-line
      * @throws InvalidArgumentException
      * @return void
      */
@@ -58,7 +57,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
     }
 
     /**
-     * @phpstan-ignore-next-line
      * @throws InvalidArgumentException
      * @return void
      */
@@ -94,7 +92,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
     }
 
     /**
-     * @phpstan-ignore-next-line
      * @throws InvalidArgumentException
      * @return void
      */
@@ -129,7 +126,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
     /**
      * @throws InvalidArgumentException
      * @return void
-     * @phpstan-ignore-next-line
      */
     public function testGetWithTagMisses(): void
     {
@@ -171,7 +167,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
     /**
      * @throws InvalidArgumentException
      * @return void
-     * @phpstan-ignore-next-line
      */
     public function testGetWithMultipleTagsMisses(): void
     {
@@ -213,7 +208,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
     /**
      * @throws InvalidArgumentException
      * @return void
-     * @phpstan-ignore-next-line
      */
     public function testGetWithTagHits(): void
     {
@@ -250,7 +244,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
     }
 
     /**
-     * @phpstan-ignore-next-line
      * @throws InvalidArgumentException
      * @return void
      */
@@ -290,7 +283,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
 
     /**
      * @throws InvalidArgumentException
-     * @phpstan-ignore-next-line
      */
     public function testIfCacheIsNotTaggable(): void
     {
@@ -320,7 +312,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
 
     /**
      * @throws InvalidArgumentException
-     * @phpstan-ignore-next-line
      */
     public function testInvalidTag(): void
     {
@@ -352,7 +343,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
 
     /**
      * @throws InvalidArgumentException
-     * @phpstan-ignore-next-line
      */
     public function testEmptyTag(): void
     {
@@ -381,7 +371,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
 
     /**
      * @throws InvalidArgumentException
-     * @phpstan-ignore-next-line
      */
     public function testInvalidCharsTag(): void
     {
@@ -409,7 +398,6 @@ class AntiStampedeCacheAdapterTest extends AntiStampedeCacheAdapterFixture
     }
 
     /**
-     * @phpstan-ignore-next-line
      * @throws InvalidArgumentException
      * @return void
      */

--- a/src/test/CacheItemTest.php
+++ b/src/test/CacheItemTest.php
@@ -6,6 +6,7 @@ use DateInterval;
 use DateTimeImmutable;
 use Psr\Cache\CacheException;
 use RuntimeException;
+use TypeError;
 use WebArch\BitrixCache\CacheItem;
 use WebArch\BitrixCache\Enum\ErrorCode;
 use WebArch\BitrixCache\Exception\InvalidArgumentException;
@@ -61,8 +62,7 @@ class CacheItemTest extends CacheItemFixture
      */
     public function testExpiresAtInvalid(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionCode(ErrorCode::INVALID_EXPIRATION_DATE);
+        $this->expectException(TypeError::class);
         /**
          * @noinspection PhpParamsInspection
          * @phpstan-ignore-next-line
@@ -112,8 +112,7 @@ class CacheItemTest extends CacheItemFixture
      */
     public function testExpiresAfterInvalid(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionCode(ErrorCode::INVALID_EXPIRATION);
+        $this->expectException(TypeError::class);
         /** @phpstan-ignore-next-line */
         $this->cacheItem->expiresAfter('invalid!');
     }
@@ -159,7 +158,6 @@ class CacheItemTest extends CacheItemFixture
     }
 
     /**
-     * @phpstan-ignore-next-line
      * @throws CacheException
      * @throws \Psr\Cache\InvalidArgumentException
      * @return void

--- a/src/test/SimpleCacheInterfaceTest.php
+++ b/src/test/SimpleCacheInterfaceTest.php
@@ -3,6 +3,7 @@
 namespace WebArch\BitrixCache\Test;
 
 use Exception;
+use TypeError;
 use WebArch\BitrixCache\Cache;
 use WebArch\BitrixCache\Enum\ErrorCode;
 use WebArch\BitrixCache\Exception\InvalidArgumentException;
@@ -514,8 +515,7 @@ class SimpleCacheInterfaceTest extends CacheFixture
     {
         $this->setUpTaggedCacheIsNeverCalled();
         $this->setUpBitrixCacheIsNeverCalled();
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionCode(ErrorCode::KEYS_IS_NOT_ARRAY);
+        $this->expectException(TypeError::class);
 
         /**
          * @noinspection PhpParamsInspection


### PR DESCRIPTION
Пришлось отказаться от поддержки от php 7, но это даёт нам совместимость с последними версиями битрикса